### PR TITLE
Add MusicBrainz ID tagging from RemoteAlbum metadata

### DIFF
--- a/src/Lidarr.Plugin.Deezer/Download/Clients/Deezer/Queue/DownloadItem.cs
+++ b/src/Lidarr.Plugin.Deezer/Download/Clients/Deezer/Queue/DownloadItem.cs
@@ -20,6 +20,8 @@ namespace NzbDrone.Core.Download.Clients.Deezer.Queue
 {
     public class DownloadItem
     {
+        public MusicBrainzIds? MusicBrainzIds { get; private set; }
+
         public static async Task<DownloadItem> From(RemoteAlbum remoteAlbum)
         {
             string url = remoteAlbum.Release.DownloadUrl.Trim();
@@ -42,6 +44,7 @@ namespace NzbDrone.Core.Download.Clients.Deezer.Queue
                     Bitrate = bitrate,
                     RemoteAlbum = remoteAlbum,
                     _deezerUrl = deezerUrl,
+                    MusicBrainzIds = ExtractMusicBrainzIds(remoteAlbum),
                 };
 
                 await item.SetDeezerData();
@@ -160,7 +163,7 @@ namespace NzbDrone.Core.Download.Clients.Deezer.Queue
                 }
             }
 
-            await DeezerAPI.Instance.Client.Downloader.ApplyMetadataToFile(track, outPath, 512, plainLyrics, token: cancellation);
+            await DeezerAPI.Instance.Client.Downloader.ApplyMetadataToFile(track, outPath, 512, plainLyrics, MusicBrainzIds, cancellation);
 
             if (syncLyrics != null)
                 await CreateLrcFile(Path.Combine(outDir, MetadataUtilities.GetFilledTemplate("%track% - %title%.%ext%", "lrc", page, _deezerAlbum)), syncLyrics);
@@ -225,6 +228,55 @@ namespace NzbDrone.Core.Download.Clients.Deezer.Queue
                     lrcContent.AppendLine(CultureInfo.InvariantCulture, $"{lyric.LrcTimestamp} {lyric.Line}");
             }
             await File.WriteAllTextAsync(lrcFilePath, lrcContent.ToString());
+        }
+
+        private static MusicBrainzIds ExtractMusicBrainzIds(RemoteAlbum remoteAlbum)
+        {
+            if (remoteAlbum == null || remoteAlbum.Artist == null || remoteAlbum.Albums == null || !remoteAlbum.Albums.Any())
+            {
+                return null;
+            }
+
+            var album = remoteAlbum.Albums[0];
+
+            // Find the monitored release
+            var monitoredRelease = album.AlbumReleases?.Value?.FirstOrDefault(r => r.Monitored);
+            if (monitoredRelease == null)
+            {
+                // Fallback: no monitored release, can't extract ReleaseId or TrackRecordingIds
+                return new MusicBrainzIds
+                {
+                    ArtistId = remoteAlbum.Artist.ForeignArtistId,
+                    ReleaseGroupId = album.ForeignAlbumId,
+                    ReleaseId = null,
+                    ReleaseArtistId = null,
+                    TrackRecordingIds = null
+                };
+            }
+
+            // Extract TrackRecordingIds from the monitored release's tracks
+            Dictionary<int, string>? trackRecordingIds = null;
+            var tracks = monitoredRelease.Tracks?.Value;
+            if (tracks != null && tracks.Any())
+            {
+                trackRecordingIds = new Dictionary<int, string>();
+                foreach (var track in tracks)
+                {
+                    if (track.AbsoluteTrackNumber > 0 && !string.IsNullOrEmpty(track.ForeignRecordingId))
+                    {
+                        trackRecordingIds[track.AbsoluteTrackNumber] = track.ForeignRecordingId;
+                    }
+                }
+            }
+
+            return new MusicBrainzIds
+            {
+                ArtistId = remoteAlbum.Artist.ForeignArtistId,
+                ReleaseGroupId = album.ForeignAlbumId,
+                ReleaseId = monitoredRelease.ForeignReleaseId,
+                ReleaseArtistId = album.Artist?.Value?.ForeignArtistId,
+                TrackRecordingIds = trackRecordingIds
+            };
         }
     }
 }

--- a/src/Lidarr.Plugin.Deezer/Lidarr.Plugin.Deezer.csproj
+++ b/src/Lidarr.Plugin.Deezer/Lidarr.Plugin.Deezer.csproj
@@ -20,7 +20,7 @@
   <ItemGroup>
     <PackageReference Include="AngleSharp" Version="1.2.0-beta.431" />
     <PackageReference Include="AngleSharp.XPath" Version="2.0.4" />
-    <PackageReference Include="DeezNET" Version="1.2.1" />
+    <PackageReference Include="DeezNET" Version="1.2.3" />
     <PackageReference Include="ILRepack.Lib.MSBuild.Task" Version="2.0.34.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
This PR adds MusicBrainz ID (MBID) tagging support to the Deezer plugin. Previously, Deezer downloads only had basic metadata from Deezer's API. With this change, the plugin now writes comprehensive MBIDs to audio file tags, enabling better library matching and metadata enrichment in Lidarr and other MusicBrainz-aware tools.

## Changes

- **Updated DeezNET dependency from 1.2.1 to 1.2.3** (required for MBID tagging support)
- **Added MusicBrainzIds property to DownloadItem class** - Holds extracted MBIDs for the download
- **Added ExtractMusicBrainzIds() helper method** - Extracts MBIDs from RemoteAlbum with graceful fallback when no monitored release is found
- **Wired MBIDs into metadata application** - Passed to ApplyMetadataToFile() call in DoTrackDownload()

### MBID Extraction Details

The `ExtractMusicBrainzIds()` method extracts:
- **ArtistId:** MusicBrainz artist ID from `remoteAlbum.Artist.ForeignArtistId`
- **ReleaseGroupId:** MusicBrainz release group ID from `album.ForeignAlbumId`
- **ReleaseId:** MusicBrainz release ID from the monitored release
- **ReleaseArtistId:** MusicBrainz release artist ID (if available)
- **TrackRecordingIds:** Dictionary mapping track numbers to MusicBrainz recording IDs

### Graceful Fallback

When no monitored release is found, the method returns a partial MBID set (ArtistId, ReleaseGroupId only). This ensures downloads complete even in edge cases where release-level metadata is missing.

## Testing

The fix has been verified to compile cleanly. Runtime testing requires a valid Deezer ARL and Lidarr instance to verify MBID tags are written correctly to downloaded audio files.

## Related

This change depends on DeezNET v1.2.3, which includes the `MusicBrainzIds` type and MBID tagging support. See jtstothard/DeezNET#3 for DeezNET MBID support.